### PR TITLE
Replace webroot_path with root_path

### DIFF
--- a/ImageOptimizer/ImageOptimizerListener.php
+++ b/ImageOptimizer/ImageOptimizerListener.php
@@ -54,7 +54,7 @@ class ImageOptimizerListener extends Listener
             $optimizer = new ImageOptimizer();
 
             $path = $asset->resolvedPath();
-            $path = webroot_path($path);
+            $path = root_path($path);
 
             $optimizer->optimize($path);
 


### PR DESCRIPTION
Fixes retrieving the incorrect path for Statamic installs above the web root where the asset container is already prefixed with the public path. Fixes issue #1